### PR TITLE
chore: fix ESLint on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "build-watch": "tsc -w",
     "debug": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect --debug-brk .'",
-    "lint": "eslint 'lib/**/*.ts' && (cd test && eslint '**/*.ts')",
+    "lint": "eslint \"lib/**/*.ts\" && (cd test && eslint \"**/*.ts\")",
     "prepare": "npm run build",
     "test": "jest"
   },


### PR DESCRIPTION
Allow linting to run on Windows by specifying double quotes in the pattern rather than single quotes.
This fixes our AppVeyor builds as well.

- [ ] Tests written and linted
- [ ] Documentation written
- [x] Commit history is tidy
- [ ] Potential release notes have been inspected

