### PR TITLE
feat: move deps into dev deps, remove unused dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
   },
   "homepage": "https://github.com/snyk/rpm-parser#readme",
   "dependencies": {
-    "@types/node": "8.10.59",
-    "eslint": "6.8.0",
     "event-loop-spinner": "1.1.0",
-    "tslib": "1.11.1",
     "typescript": "3.8.3"
   },
   "devDependencies": {
+    "@types/node": "8.10.59",
     "@types/jest": "23.3.14",
     "@typescript-eslint/eslint-plugin": "2.25.0",
     "@typescript-eslint/parser": "2.25.0",
+    "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.1",
     "jest": "23.6.0",
     "ts-jest": "23.10.5",


### PR DESCRIPTION
One dependency was unused here, and some others need to be in `devDependencies` as they are not required at run time.

Without this change, we will end up with a vulnerable CLI due to transitive dependencies via this package.