### PR TITLE
feat: typescript is a dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,11 @@
   },
   "homepage": "https://github.com/snyk/rpm-parser#readme",
   "dependencies": {
-    "event-loop-spinner": "1.1.0",
-    "typescript": "3.8.3"
+    "event-loop-spinner": "1.1.0"
   },
   "devDependencies": {
-    "@types/node": "8.10.59",
     "@types/jest": "23.3.14",
+    "@types/node": "8.10.59",
     "@typescript-eslint/eslint-plugin": "2.25.0",
     "@typescript-eslint/parser": "2.25.0",
     "eslint": "6.8.0",
@@ -35,6 +34,7 @@
     "jest": "23.6.0",
     "ts-jest": "23.10.5",
     "ts-node": "7.0.0",
-    "tsc-watch": "4.2.3"
+    "tsc-watch": "4.2.3",
+    "typescript": "^3.9.2"
   }
 }


### PR DESCRIPTION
### What this does

`typescript` is a prod dep, so that users of the library (including the CLI) don't have to do the extra 50MB download.