### PR TITLE
[RUN-945] feat: move typescript to dev-deps to reduce CLI size

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/snyk/rpm-parser#readme",
   "dependencies": {
-    "event-loop-spinner": "1.1.0",
-    "typescript": "3.8.3"
+    "event-loop-spinner": "1.1.0"
   },
   "devDependencies": {
     "@types/node": "8.10.59",
@@ -35,6 +34,7 @@
     "jest": "23.6.0",
     "ts-jest": "23.10.5",
     "ts-node": "7.0.0",
-    "tsc-watch": "4.2.3"
+    "tsc-watch": "4.2.3",
+    "typescript": "3.8.3"
   }
 }


### PR DESCRIPTION
- [x] Commit history is tidy
- [x] Potential release notes have been inspected

### What this does

Remove `typescript` from prod deps so that users don't have to install it (~50mb download) when they install the library.
