### PR TITLE
feat: newer event-loop-spinner and node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/snyk/rpm-parser#readme",
   "dependencies": {
-    "event-loop-spinner": "1.1.0"
+    "event-loop-spinner": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "8.10.59",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es2015",
+    "target": "es2017",
     "lib": [
-        "es2015",
-        "es2016.array.include",
+        "es2017",
     ],
     "module": "commonjs",
     "sourceMap": true,


### PR DESCRIPTION
### What this does

> The new event-loop-spinner can better share its state with other libraries, reducing the waits for everyone.

> BREAKING CHANGE: will no longer work on node 6
> This was already set in the `engines` field, and in `.nvmrc`, and CI, so is probably not too controversial.
> As we have performance sensitive code which is async, it's probably (untested) better to let the compiler take advantage of the platform we actually support.