### PR TITLE
fix/exclude private tags

### DIFF
--- a/lib/rpm/header.ts
+++ b/lib/rpm/header.ts
@@ -1,6 +1,11 @@
 import { eventLoopSpinner } from 'event-loop-spinner';
 
-import { IndexEntry, ENTRY_INFO_SIZE, EntryInfo } from './types';
+import {
+  IndexEntry,
+  ENTRY_INFO_SIZE,
+  EntryInfo,
+  PRIVATE_RPM_TAGS,
+} from './types';
 import { ParserError } from '../types';
 
 /**
@@ -40,6 +45,10 @@ export async function headerImport(data: Buffer): Promise<IndexEntry[]> {
       offset: entry.readInt32BE(8),
       count: entry.readUInt32BE(12),
     };
+
+    if (PRIVATE_RPM_TAGS.includes(entryInfo.tag)) {
+      continue;
+    }
 
     entryInfos.push(entryInfo);
 

--- a/lib/rpm/types.ts
+++ b/lib/rpm/types.ts
@@ -3,7 +3,21 @@
  */
 export const ENTRY_INFO_SIZE = 16;
 
+/** https://github.com/rpm-software-management/rpm/blob/ad1cad7e6a5def8b6036b90f2634297eda79dc7d/lib/rpmtag.h#L16-L25 */
+export const PRIVATE_RPM_TAGS: ReadonlyArray<number> = [
+  61, // Image
+  62, // Signatures
+  63, // Immutable
+  64, // Regions
+  100, // Internationalization table
+  256, // Signature base
+];
+
 export interface EntryInfo {
+  /**
+   * See the following for a full list of RPM tags:
+   * https://github.com/rpm-software-management/rpm/blob/ad1cad7e6a5def8b6036b90f2634297eda79dc7d/doc/manual/tags.md
+   */
   tag: number; // Int32, Tag identifier.
   type: number; // UInt32, Tag data type.
   offset: number; // Int32, Offset into data segment (on-disk only).

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build-watch": "tsc -w",
     "debug": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect --debug-brk .'",
     "lint": "eslint \"lib/**/*.ts\" && (cd test && eslint \"**/*.ts\")",
+    "format": "prettier --write \"lib/**/*.ts\" \"test/**/*.ts\"",
     "prepare": "npm run build",
     "test": "jest"
   },
@@ -25,13 +26,14 @@
     "event-loop-spinner": "^2.0.0"
   },
   "devDependencies": {
-    "@types/node": "8.10.59",
     "@types/jest": "23.3.14",
+    "@types/node": "8.10.59",
     "@typescript-eslint/eslint-plugin": "2.25.0",
     "@typescript-eslint/parser": "2.25.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.1",
     "jest": "23.6.0",
+    "prettier": "2.1.2",
     "ts-jest": "23.10.5",
     "ts-node": "7.0.0",
     "tsc-watch": "4.2.3",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -39,14 +39,8 @@ describe('Testing various RPM databases', () => {
       expect(parserOutput.rpmMetadata).toBeDefined();
       expect(parserOutput.rpmMetadata!.packagesSkipped).toEqual(0);
 
-      const expectedEntries = expectedOutput
-        .trim()
-        .split('\n')
-        .sort();
-      const parserEntries = parserOutput.response
-        .trim()
-        .split('\n')
-        .sort();
+      const expectedEntries = expectedOutput.trim().split('\n').sort();
+      const parserEntries = parserOutput.response.trim().split('\n').sort();
 
       for (let j = 0; j < expectedEntries.length; j++) {
         const expectedEntry = expectedEntries[j];


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written
- [x] Commit history is tidy
- [x] Potential release notes have been inspected

### What this does

Exclude blobs with private RPM tags when reading dependencies.
These blobs did not produce accurate calculations (e.g. they had a negative size) because they were not meant to be read like the rest of the blobs.

