### PR TITLE
Chore/use sql js

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,8 +2,8 @@ import { bufferToHashDbValues } from './berkeleydb';
 import { bufferToPackageInfo } from './rpm';
 import { PackageInfo } from './rpm/types';
 import { IParserBerkeleyResponse, IParserSqliteResponse, ParserError } from './types';
-import { Database } from 'sqlite3';
-import { open } from 'sqlite';
+import { default as initSqlJs } from 'sql.js';
+
 /**
  * Get a list of packages given a Buffer that contains an RPM database in BerkeleyDB format.
  * The database is inspected as best-effort, returning all valid/readable entries.
@@ -65,21 +65,24 @@ function formatRpmPackages(packages: PackageInfo[]): string[] {
  * The database is inspected as best-effort, returning all valid/readable entries.
  * @param sqliteFilePath A path to an RPM sqlite Packages DB.
  */
-
-export async function getPackagesSqlite(sqliteFilePath: string): Promise<IParserSqliteResponse> {
+export async function getPackagesSqlite(sqliteDbBuffer: Buffer): Promise<IParserSqliteResponse> {
   try {
-    const db = await open({
-      filename: sqliteFilePath,
-      driver: Database
-    });
-
-    const dbContent: { blob: Buffer }[] = await db.all('SELECT blob FROM Packages');
-    const packagesInfoBlobs = dbContent.map((pkg) => bufferToPackageInfo(pkg.blob));
-    const packages = await Promise.all(packagesInfoBlobs);
-    db.close();
+    const packageInfoBlobs = await getBlobsFromPackagesTableSqliteDb(sqliteDbBuffer);
+    const packages = await Promise.all(packageInfoBlobs.map((data: Buffer) => bufferToPackageInfo(data)));
     return { response: packages as PackageInfo[] };
   }
   catch (error) {
     return { response: [], error: error as ParserError };
   }
+}
+
+// TODO: revisit when new version of sql.js is available
+// OR we're able to use sqlite3 (Snyk CLI limitation with native modules)
+async function getBlobsFromPackagesTableSqliteDb(sqliteDbBuffer: Buffer): Promise<Buffer[]> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(sqliteDbBuffer);
+  const dbContent = db.exec("SELECT blob FROM Packages");
+  const packagesInfoBlobs = dbContent[0].values;
+  db.close();
+  return packagesInfoBlobs.map((data) => (Buffer.from(data[0] as Uint8Array)));
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import { PackageInfo } from "./rpm/types";
+import { PackageInfo } from './rpm/types';
 
 export interface IParserBerkeleyResponse {
   response: string;

--- a/package.json
+++ b/package.json
@@ -24,13 +24,12 @@
   "homepage": "https://github.com/snyk/rpm-parser#readme",
   "dependencies": {
     "event-loop-spinner": "^2.2.0",
-    "sqlite": "^4.1.1",
-    "sqlite3": "^5.0.8"
+    "sql.js": "^1.7.0"
   },
   "devDependencies": {
     "@types/jest": "23.3.14",
     "@types/node": "^12.20.54",
-    "@types/sqlite3": "^3.1.8",
+    "@types/sql.js": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "2.25.0",
     "@typescript-eslint/parser": "2.25.0",
     "eslint": "6.8.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "build-watch": "tsc -w",
     "debug": "tsc-watch --project tsconfig.json --onSuccess 'node --inspect --debug-brk .'",
-    "lint": "eslint \"lib/**/*.ts\" && (cd test && eslint \"**/*.ts\")",
+    "lint": "eslint \"lib/**/*.ts\" && (cd test && eslint \"**/*.ts\") && prettier --check \"lib/**/*.ts\" \"test/**/*.ts\"",
     "format": "prettier --write \"lib/**/*.ts\" \"test/**/*.ts\"",
     "prepare": "npm run build",
     "test": "jest"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,8 +51,7 @@ describe('Testing various RPM Berkeley databases', () => {
   }
 });
 
-
-describe("Testing various RPM sqlite databases", async () => {
+describe('Testing various RPM sqlite databases', async () => {
   const fixtureDir: string = fixturePath('fixtures/rpm-4.16');
   const outputDir: string = fixturePath('outputs/rpm-4.16');
 
@@ -61,7 +60,9 @@ describe("Testing various RPM sqlite databases", async () => {
   for (const path of fixturesFileNames) {
     test(`testing ${path}`, async () => {
       const expectedOutput = readFileSync(`${outputDir}/${path}`, 'utf8');
-      const packagesDbContent = (await getPackagesSqlite(readFileSync(`${fixtureDir}/${path}`))).response;
+      const packagesDbContent = (
+        await getPackagesSqlite(readFileSync(`${fixtureDir}/${path}`))
+      ).response;
       expect(packagesDbContent).toMatchObject(JSON.parse(expectedOutput));
     });
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -61,7 +61,7 @@ describe("Testing various RPM sqlite databases", async () => {
   for (const path of fixturesFileNames) {
     test(`testing ${path}`, async () => {
       const expectedOutput = readFileSync(`${outputDir}/${path}`, 'utf8');
-      const packagesDbContent = (await getPackagesSqlite(`${fixtureDir}/${path}`)).response;
+      const packagesDbContent = (await getPackagesSqlite(readFileSync(`${fixtureDir}/${path}`))).response;
       expect(packagesDbContent).toMatchObject(JSON.parse(expectedOutput));
     });
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2017",
     "lib": [
         "es2017",
+        "DOM", // needed because of sql.js lib
     ],
     "module": "commonjs",
     "sourceMap": true,


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written
- [ ] Commit history is tidy
- [ ] Potential release notes have been inspected

### What this does

Due to a limitation in Snyk's CLI - we need to replace `sqlite` / `sqlite3` with a lib that doesn't use native modules - `sql.js`.

The second commit is to properly use prettier linting and fix some warnings. 
