### PR TITLE
refactor: extract version formatting to a new func

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -58,12 +58,17 @@ export async function getPackages(
 
 function formatRpmPackages(packages: PackageInfo[]): string[] {
   return packages.map((packageInfo) => {
-    if (packageInfo.epoch === undefined || packageInfo.epoch === 0) {
-      return `${packageInfo.name}\t${packageInfo.version}-${packageInfo.release}\t${packageInfo.size}`;
-    } else {
-      return `${packageInfo.name}\t${packageInfo.epoch}:${packageInfo.version}-${packageInfo.release}\t${packageInfo.size}`;
-    }
+    return `${packageInfo.name}\t${formatRpmPackageVersion(packageInfo)}\t${
+      packageInfo.size
+    }`;
   });
+}
+
+export function formatRpmPackageVersion(packageInfo: PackageInfo): string {
+  if (packageInfo.epoch === undefined || packageInfo.epoch === 0) {
+    return `${packageInfo.version}-${packageInfo.release}`;
+  }
+  return `${packageInfo.epoch}:${packageInfo.version}-${packageInfo.release}`;
 }
 
 /**

--- a/test/unit/rpm/version.spec.ts
+++ b/test/unit/rpm/version.spec.ts
@@ -1,0 +1,40 @@
+import { formatRpmPackageVersion } from '../../../lib';
+import { PackageInfo } from '../../../lib/rpm/types';
+
+describe('version parsing', () => {
+  it('parses version with epoch undefined', () => {
+    const rpmPackage: PackageInfo = {
+      name: 'pkg',
+      version: '1.2.3',
+      epoch: undefined,
+      release: '1',
+      size: 1,
+    };
+
+    expect(formatRpmPackageVersion(rpmPackage)).toBe('1.2.3-1');
+  });
+
+  it('parses version with epoch 0', () => {
+    const rpmPackage: PackageInfo = {
+      name: 'pkg',
+      version: '1.2.3',
+      epoch: 0,
+      release: '1',
+      size: 1,
+    };
+
+    expect(formatRpmPackageVersion(rpmPackage)).toBe('1.2.3-1');
+  });
+
+  it('parses version with epoch and release', () => {
+    const rpmPackage: PackageInfo = {
+      name: 'pkg',
+      version: '1.2.3',
+      epoch: 1,
+      release: '1',
+      size: 1,
+    };
+
+    expect(formatRpmPackageVersion(rpmPackage)).toBe('1:1.2.3-1');
+  });
+});


### PR DESCRIPTION
Extracting version formatting (adding epoch and release to the version string) to another exported function.

