### PR TITLE
refactor: Change return types

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,16 +1,12 @@
 import { PackageInfo } from './rpm/types';
 
-export interface IParserBerkeleyResponse {
-  response: string;
-  rpmMetadata?: IRpmMetadata;
-  error?: ParserError;
-}
-export interface IParserSqliteResponse {
+export interface Response {
   response: PackageInfo[];
-  rpmMetadata?: IRpmMetadata;
+  rpmMetadata?: RpmMetadata;
   error?: ParserError;
 }
-export interface IRpmMetadata {
+
+export interface RpmMetadata {
   packagesProcessed: number;
   packagesSkipped: number;
 }


### PR DESCRIPTION
BREAKING CHANGE: changes the returned type from the extracting function `getPackages`.  So far a string has been returned, which delimited each entry in the DB with a newline, and each part of the entry with a tab. Instead, we now pass a proper type back to the caller, making it easier to have (and parse) optional fields.
