### PR TITLE
feat: added parsing of sourceRPM field

### DIFF
--- a/lib/rpm/extensions.ts
+++ b/lib/rpm/extensions.ts
@@ -78,6 +78,16 @@ export async function getPackageInfo(
         packageInfo.module = extractString(entry.data);
         break;
 
+      case RpmTag.SOURCERPM:
+        if (entry.info.type !== RpmType.STRING) {
+          throw new ParserError('Unexpected type for sourceRPM tag', {
+            type: entry.info.type,
+          });
+        }
+
+        packageInfo.sourceRPM = extractString(entry.data);
+        break;
+
       default:
         break;
     }

--- a/lib/rpm/types.ts
+++ b/lib/rpm/types.ts
@@ -42,6 +42,7 @@ export interface PackageInfo {
   arch?: string;
   epoch?: number;
   module?: string;
+  sourceRPM?: string;
 }
 
 export enum RpmTag {
@@ -52,6 +53,7 @@ export enum RpmTag {
   SIZE = 1009,
   ARCH = 1022,
   MODULARITYLABEL = 5096,
+  SOURCERPM = 1044,
 }
 
 export enum RpmType {

--- a/test/unit/rpm/extensions.test.ts
+++ b/test/unit/rpm/extensions.test.ts
@@ -9,6 +9,7 @@ describe('getPackageInfo()', () => {
     const version = '1.2.3\0';
     const module = 'perl-libwww-perl:6.34:8030020200716155257:b967a9a2\0';
     const size = [0x00, 0x00, 0x00, 0x01]; // 1 in Big Endian
+    const sourceRPM = 'package-1.2.3-rel.src.rpm\0';
 
     const nameEntry = {
       info: {
@@ -60,6 +61,16 @@ describe('getPackageInfo()', () => {
       data: Buffer.from(module),
       length: 0,
     };
+    const sourceRPMEntry = {
+      info: {
+        tag: RpmTag.SOURCERPM,
+        type: RpmType.STRING,
+        count: 0,
+        offset: 0,
+      },
+      data: Buffer.from(sourceRPM),
+      length: 0,
+    };
 
     const packageEntries: IndexEntry[] = [
       nameEntry,
@@ -67,6 +78,7 @@ describe('getPackageInfo()', () => {
       versionEntry,
       sizeEntry,
       moduleEntry,
+      sourceRPMEntry,
     ];
 
     await expect(getPackageInfo(packageEntries)).resolves.toEqual({
@@ -75,6 +87,7 @@ describe('getPackageInfo()', () => {
       version: '1.2.3',
       module: 'perl-libwww-perl:6.34:8030020200716155257:b967a9a2',
       size: 1,
+      sourceRPM: 'package-1.2.3-rel.src.rpm',
     });
   });
 


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written
- [ ] Commit history is tidy
- [ ] Potential release notes have been inspected

### What this does

Add support in the RPM parser to parse the sourceRPM field in for packages in the RPM db file in the container image. Needed for Red Hat Vulnerability Scanner Certification after RHEL 10 is released.

### Notes for the reviewer

The sourceRPM field is optional in the package db.

### More information

- [Jira ticket CN-68](https://snyksec.atlassian.net/browse/CN-68)
- [Link to documentation](https://github.com/snyk/rpm-parser/blob/master/README.md)

